### PR TITLE
Add BeAnOsIsNotExistError matcher

### DIFF
--- a/os_is_not_exist_matcher.go
+++ b/os_is_not_exist_matcher.go
@@ -1,0 +1,30 @@
+package gomegamatchers
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/onsi/gomega/types"
+)
+
+func BeAnOsIsNotExistError() types.GomegaMatcher {
+	return &osIsNotExistErrorMatcher{}
+}
+
+type osIsNotExistErrorMatcher struct{}
+
+func (matcher *osIsNotExistErrorMatcher) Match(actual interface{}) (success bool, err error) {
+	err, ok := actual.(error)
+	if !ok {
+		return false, fmt.Errorf("BeAnOsIsNotExistError matcher expects an error, got %#v", actual)
+	}
+	return os.IsNotExist(err), nil
+}
+
+func (matcher *osIsNotExistErrorMatcher) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected %#v\nto be an os.IsNotExist error", actual)
+}
+
+func (matcher *osIsNotExistErrorMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected %#v\nnot to be an os.IsNotExist error", actual)
+}

--- a/os_is_not_exist_matcher_test.go
+++ b/os_is_not_exist_matcher_test.go
@@ -1,0 +1,23 @@
+package gomegamatchers_test
+
+import (
+	"errors"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf-experimental/gomegamatchers"
+)
+
+var _ = Describe("OsIsNotExistMatcher", func() {
+	It("asserts if an error is an os.IsNotExist error", func() {
+		Expect(os.ErrNotExist).To(gomegamatchers.BeAnOsIsNotExistError())
+		Expect(errors.New("foo")).ToNot(gomegamatchers.BeAnOsIsNotExistError())
+	})
+
+	It("errors when not passed an error", func() {
+		var foo error
+		_, err := gomegamatchers.BeAnOsIsNotExistError().Match(foo)
+		Expect(err).To(MatchError("BeAnOsIsNotExistError matcher expects an error, got <nil>"))
+	})
+})


### PR DESCRIPTION
This lets us do OS agnostic testing for filesystem errors. We found it handier than doing

```
Expect(os.IsNotExist(err)).To(BeTrue())
```

since it gives you a better error message than `expected false to be true`.